### PR TITLE
Add `AzureMachineClass` resource to ClusterRole

### DIFF
--- a/kubernetes/deployment/clusterrole.yaml
+++ b/kubernetes/deployment/clusterrole.yaml
@@ -11,6 +11,7 @@ rules:
   - "machine.sapcloud.io"
   resources:
   - awsmachineclasses
+  - azuremachineclasses
   - machinedeployments
   - machines
   - machinesets


### PR DESCRIPTION
After integrating Azure the example ClusterRole for the node-controller-manager has not been updated.