### PR TITLE
Add AzureMachineClass[List] to Scheme

### DIFF
--- a/pkg/apis/machine/register.go
+++ b/pkg/apis/machine/register.go
@@ -50,6 +50,9 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&AWSMachineClass{},
 		&AWSMachineClassList{},
 
+		&AzureMachineClass{},
+		&AzureMachineClassList{},
+
 		&Machine{},
 		&MachineList{},
 

--- a/pkg/apis/machine/v1alpha1/register.go
+++ b/pkg/apis/machine/v1alpha1/register.go
@@ -55,6 +55,9 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&AWSMachineClass{},
 		&AWSMachineClassList{},
 
+		&AzureMachineClass{},
+		&AzureMachineClassList{},
+
 		&Machine{},
 		&MachineList{},
 


### PR DESCRIPTION
After integrating Azure the new structs have not been added to the scheme. The node-controller-manager cannot report events on those objects.

