### PR TITLE
AWS VMs "Name" tag defaults to machine object name

### DIFF
--- a/pkg/driver/driver_aws.go
+++ b/pkg/driver/driver_aws.go
@@ -99,6 +99,11 @@ func (d *AWSDriver) Create() (string, string, error) {
 
 	// Add tags to the created machine
 	tagList := []*ec2.Tag{}
+	// If no "Name" tag has been specified in the MachineClass definition we set the "Name" tag's
+	// value to "name-of-machine-object".
+	if _, ok := d.AWSMachineClass.Spec.Tags["Name"]; !ok {
+		d.AWSMachineClass.Spec.Tags["Name"] = d.MachineName
+	}
 	for idx, element := range d.AWSMachineClass.Spec.Tags {
 		newTag := ec2.Tag{
 			Key:   aws.String(idx),


### PR DESCRIPTION
- In the `AWSMachineClass` object it is possible to define tags which are applied to the VM.
- If no tag with key `Name` has been defined in the class, the AWS driver will default it to the name of the machine object it acts on.
- Otherwise, the value provided in the class is taken.

closes #10 