### PR TITLE
Change the term 'availabilityZone' to 'region' in AWSMachineClass

### DIFF
--- a/kubernetes/aws-machine-class.yaml
+++ b/kubernetes/aws-machine-class.yaml
@@ -6,7 +6,7 @@ metadata:
   name: test-aws # Name of aws machine class goes here
 spec:
   ami: ami-123456 # Amazon machine image name goes here
-  availabilityZone: eu-east-1 # Region in which machine is to be deployed
+  region: eu-east-1 # Region in which machine is to be deployed
   machineType: t2.large # Type of ec2 machine
   iam:
     name: iam-name # Name of the AWS Identity and Access Management

--- a/pkg/apis/machine/types.go
+++ b/pkg/apis/machine/types.go
@@ -669,7 +669,7 @@ type AWSMachineClassList struct {
 // AWSMachineClassSpec is the specification of a cluster.
 type AWSMachineClassSpec struct {
 	AMI               string
-	AvailabilityZone  string
+	Region            string
 	BlockDevices      []AWSBlockDeviceMappingSpec
 	EbsOptimized      bool
 	IAM               AWSIAMProfileSpec

--- a/pkg/apis/machine/v1alpha1/types.go
+++ b/pkg/apis/machine/v1alpha1/types.go
@@ -669,7 +669,7 @@ type AWSMachineClassList struct {
 // AWSMachineClassSpec is the specification of a cluster.
 type AWSMachineClassSpec struct {
 	AMI               string                      `json:"ami,omitempty"`
-	AvailabilityZone  string                      `json:"availabilityZone,omitempty"`
+	Region            string                      `json:"region,omitempty"`
 	BlockDevices      []AWSBlockDeviceMappingSpec `json:"blockDevices,omitempty"`
 	EbsOptimized      bool                        `json:"ebsOptimized,omitempty"`
 	IAM               AWSIAMProfileSpec           `json:"iam,omitempty"`

--- a/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
@@ -276,7 +276,7 @@ func Convert_machine_AWSMachineClassList_To_v1alpha1_AWSMachineClassList(in *mac
 
 func autoConvert_v1alpha1_AWSMachineClassSpec_To_machine_AWSMachineClassSpec(in *AWSMachineClassSpec, out *machine.AWSMachineClassSpec, s conversion.Scope) error {
 	out.AMI = in.AMI
-	out.AvailabilityZone = in.AvailabilityZone
+	out.Region = in.Region
 	out.BlockDevices = *(*[]machine.AWSBlockDeviceMappingSpec)(unsafe.Pointer(&in.BlockDevices))
 	out.EbsOptimized = in.EbsOptimized
 	if err := Convert_v1alpha1_AWSIAMProfileSpec_To_machine_AWSIAMProfileSpec(&in.IAM, &out.IAM, s); err != nil {
@@ -298,7 +298,7 @@ func Convert_v1alpha1_AWSMachineClassSpec_To_machine_AWSMachineClassSpec(in *AWS
 
 func autoConvert_machine_AWSMachineClassSpec_To_v1alpha1_AWSMachineClassSpec(in *machine.AWSMachineClassSpec, out *AWSMachineClassSpec, s conversion.Scope) error {
 	out.AMI = in.AMI
-	out.AvailabilityZone = in.AvailabilityZone
+	out.Region = in.Region
 	out.BlockDevices = *(*[]AWSBlockDeviceMappingSpec)(unsafe.Pointer(&in.BlockDevices))
 	out.EbsOptimized = in.EbsOptimized
 	if err := Convert_machine_AWSIAMProfileSpec_To_v1alpha1_AWSIAMProfileSpec(&in.IAM, &out.IAM, s); err != nil {

--- a/pkg/apis/machine/validation/awsmachineclass.go
+++ b/pkg/apis/machine/validation/awsmachineclass.go
@@ -68,8 +68,8 @@ func validateAWSMachineClassSpec(spec *machine.AWSMachineClassSpec, fldPath *fie
 	if "" == spec.AMI {
 		allErrs = append(allErrs, field.Required(fldPath.Child("ami"), "AMI is required"))
 	}
-	if "" == spec.AvailabilityZone {
-		allErrs = append(allErrs, field.Required(fldPath.Child("availabilityZone"), "AvailabilityZone is required"))
+	if "" == spec.Region {
+		allErrs = append(allErrs, field.Required(fldPath.Child("region"), "Region is required"))
 	}
 	if "" == spec.MachineType {
 		allErrs = append(allErrs, field.Required(fldPath.Child("machineType"), "MachineType is required"))

--- a/pkg/driver/driver_aws.go
+++ b/pkg/driver/driver_aws.go
@@ -115,7 +115,7 @@ func (d *AWSDriver) Create() (string, string, error) {
 		return "Error", "Error", errtag
 	}
 
-	return d.encodeMachineId(d.AWSMachineClass.Spec.AvailabilityZone, *runResult.Instances[0].InstanceId), *runResult.Instances[0].PrivateDnsName, nil
+	return d.encodeMachineId(d.AWSMachineClass.Spec.Region, *runResult.Instances[0].InstanceId), *runResult.Instances[0].PrivateDnsName, nil
 }
 
 // Delete TODO
@@ -170,7 +170,7 @@ func (d *AWSDriver) createSVC() *ec2.EC2 {
 
 	if accessKeyID != "" && secretAccessKey != "" {
 		return ec2.New(session.New(&aws.Config{
-			Region: aws.String(d.AWSMachineClass.Spec.AvailabilityZone),
+			Region: aws.String(d.AWSMachineClass.Spec.Region),
 			Credentials: credentials.NewStaticCredentialsFromCreds(credentials.Value{
 				AccessKeyID:     accessKeyID,
 				SecretAccessKey: secretAccessKey,
@@ -179,12 +179,12 @@ func (d *AWSDriver) createSVC() *ec2.EC2 {
 	}
 
 	return ec2.New(session.New(&aws.Config{
-		Region: aws.String(d.AWSMachineClass.Spec.AvailabilityZone),
+		Region: aws.String(d.AWSMachineClass.Spec.Region),
 	}))
 }
 
-func (d *AWSDriver) encodeMachineId(availabilityZone, instanceId string) string {
-	return fmt.Sprintf("aws:///%s/%s", availabilityZone, instanceId)
+func (d *AWSDriver) encodeMachineId(region, instanceId string) string {
+	return fmt.Sprintf("aws:///%s/%s", region, instanceId)
 }
 
 func (d *AWSDriver) decodeMachineId(id string) string {

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -223,7 +223,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format: "",
 							},
 						},
-						"availabilityZone": {
+						"region": {
 							SchemaProps: spec.SchemaProps{
 								Type:   []string{"string"},
 								Format: "",


### PR DESCRIPTION
Mentioned in the node-controller-manager's TODO document (point 12).

Although the AWS SDK calls it "availability zone" the user is expected to enter an AWS region.